### PR TITLE
feat(immich): deploy resource-efficient photo management with external services

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A continuación, una lista representativa (en expansión) de las aplicaciones de
 | Aplicación    | Descripción                                        | Expuesta Externamente |
 | :------------ | :------------------------------------------------- | :--------------------- |
 | Jellyfin      | Servidor multimedia para streaming personal        | Sí                     |
+| Immich        | Plataforma de gestión de fotos y videos de código abierto con búsqueda por IA (VectorChord) | Sí |
 | Linkding      | Gestor de marcadores minimalista                   | Sí                     |
 | Grafana       | Paneles de monitoreo y visualización               | Sí                     |
 | Memos         | Notas y gestión de ideas personales                | Sí                     |

--- a/apps/base/immich/kustomization.yaml
+++ b/apps/base/immich/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: immich
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - storage.yaml
+  - release.yaml

--- a/apps/base/immich/namespace.yaml
+++ b/apps/base/immich/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: immich
+  labels:
+    k8s.dimarco-server.site/scrape: "true"
+    goldilocks.fairwinds.com/enabled: "true"

--- a/apps/base/immich/release.yaml
+++ b/apps/base/immich/release.yaml
@@ -37,8 +37,16 @@ spec:
                   secretKeyRef:
                     name: immich-db-credentials
                     key: DB_PASSWORD
-              REDIS_HOSTNAME: 192.168.1.33
-              REDIS_PORT: "6379"
+              REDIS_HOSTNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-db-credentials
+                    key: REDIS_HOSTNAME
+              REDIS_PORT:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-db-credentials
+                    key: REDIS_PORT
               IMMICH_MACHINE_LEARNING_ENABLED: "false"
             resources:
               requests:

--- a/apps/base/immich/release.yaml
+++ b/apps/base/immich/release.yaml
@@ -1,0 +1,85 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: immich
+  namespace: immich
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: immich
+      version: "0.13.1"
+      sourceRef:
+        kind: HelmRepository
+        name: immich
+        namespace: immich
+      interval: 12h
+
+  values:
+    controllers:
+      main:
+        containers:
+          main:
+            image:
+              repository: ghcr.io/immich-app/immich-server
+              tag: v3.0.0
+            env:
+              DB_HOSTNAME: pg-immich.data.dimarco-server.site
+              DB_PORT: "5432"
+              DB_DATABASE_NAME: immich
+              DB_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-db-credentials
+                    key: DB_USERNAME
+              DB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: immich-db-credentials
+                    key: DB_PASSWORD
+              REDIS_HOSTNAME: 192.168.1.33
+              REDIS_PORT: "6379"
+              IMMICH_MACHINE_LEARNING_ENABLED: "false"
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 250m
+              limits:
+                memory: 1.5Gi
+                cpu: 1000m
+
+        replicaCount: 1
+
+    server:
+      enabled: true
+      ingress:
+        main:
+          enabled: true
+          className: nginx
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt-production
+            external-dns.kubernetes.io/ignore: "true"
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
+            nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
+            nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+          hosts:
+            - host: immich.dimarco-server.site
+              paths:
+                - path: /
+                  pathType: Prefix
+          tls:
+            - hosts:
+                - immich.dimarco-server.site
+              secretName: immich-tls
+
+    machine-learning:
+      enabled: false
+
+    valkey:
+      enabled: false
+
+    immich:
+      persistence:
+        library:
+          existingClaim: immich-library-pvc

--- a/apps/base/immich/release.yaml
+++ b/apps/base/immich/release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: immich
-      version: "0.13.1"
+      version: "0.12.0"
       sourceRef:
         kind: HelmRepository
         name: immich
@@ -22,7 +22,7 @@ spec:
           main:
             image:
               repository: ghcr.io/immich-app/immich-server
-              tag: v3.0.0
+              tag: v2.6.3
             env:
               DB_HOSTNAME: pg-immich.data.dimarco-server.site
               DB_PORT: "5432"

--- a/apps/base/immich/release.yaml
+++ b/apps/base/immich/release.yaml
@@ -53,8 +53,8 @@ spec:
                 memory: 512Mi
                 cpu: 250m
               limits:
-                memory: 1.5Gi
-                cpu: 1000m
+                memory: 2.5Gi
+                cpu: 1500m
 
         replicaCount: 1
 

--- a/apps/base/immich/repository.yaml
+++ b/apps/base/immich/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: immich
+  namespace: immich
+spec:
+  interval: 24h
+  url: https://immich-app.github.io/immich-charts/

--- a/apps/base/immich/storage.yaml
+++ b/apps/base/immich/storage.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: immich-library-pv
+spec:
+  storageClassName: ""
+  capacity:
+    storage: 2Ti
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: 192.168.1.79
+    path: "/volume1/Proxmox/Media/immich"
+    readOnly: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-library-pvc
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Ti
+  volumeName: immich-library-pv

--- a/apps/gordito/immich/kustomization.yaml
+++ b/apps/gordito/immich/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: immich
+resources:
+  - ../../base/immich/
+  - secret.yaml

--- a/apps/gordito/immich/secret.yaml
+++ b/apps/gordito/immich/secret.yaml
@@ -17,3 +17,9 @@ spec:
     - secretKey: DB_PASSWORD
       remoteRef:
         key: /databases/immich/IMMICH_DB_PASSWORD
+    - secretKey: REDIS_HOSTNAME
+      remoteRef:
+        key: /immich/REDIS_HOSTNAME
+    - secretKey: REDIS_PORT
+      remoteRef:
+        key: /immich/REDIS_PORT

--- a/apps/gordito/immich/secret.yaml
+++ b/apps/gordito/immich/secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: immich-db-credentials
+  namespace: immich
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: immich-db-credentials
+  data:
+    - secretKey: DB_USERNAME
+      remoteRef:
+        key: /databases/immich/IMMICH_DB_USER
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: /databases/immich/IMMICH_DB_PASSWORD

--- a/apps/gordito/kustomization.yaml
+++ b/apps/gordito/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - n8n
   - memos
   - bytestash
+  - immich
   # - ollama
   # - redlib  # Disabled: Reddit is blocking OAuth client creation
   - dbgate

--- a/clusters/gordito/flux-system/gotk-sync.yaml
+++ b/clusters/gordito/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feat/immich-deployment
   secretRef:
     name: flux-system
   url: ssh://git@github.com/octaviodimarco/homelab

--- a/clusters/gordito/flux-system/gotk-sync.yaml
+++ b/clusters/gordito/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feat/immich-deployment
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/octaviodimarco/homelab


### PR DESCRIPTION
## Summary

Deploy Immich v2.6.3 as a resource-efficient photo library management system
leveraging external infrastructure to minimize cluster overhead:

- **Database**: CloudNativePG PostgreSQL cluster in data cluster with VectorChord
  extension for AI-powered search capabilities
- **Cache**: External Redis on Proxmox LXC (no bundled dependencies)
- **Storage**: Synology NAS via NFS for photo library (/volume1/Proxmox/Media/immich)
- **ML**: Fully disabled to reduce CPU/memory footprint for 2-user setup
- **Ingress**: HTTPS via Let's Encrypt on immich.dimarco-server.site

## Changes

- **Infrastructure (main branch)**:
  - Expanded data cluster MetalLB pool from 240-254 to 248-254 (7 IPs total)
  - Added immich PostgreSQL cluster with pgvector + vchord extensions
  - Configured external-dns hostname: pg-immich.data.dimarco-server.site

- **Application (feat/immich-deployment branch)**:
  - HelmRelease for immich-charts v0.12.0 (Immich v2.6.3)
  - Memory allocation: 2.5Gi limits (bumped from 1.5Gi to handle video transcoding)
  - Secrets management via Infisical for DB and Redis credentials
  - Persistent storage via manual NFS PV for photo library
  - Ingress with proxy-body-size=0 for large media uploads

## Technical Details

- **Cluster placement**: immich-server on k3s-nixos-worker (8Gi available)
- **Resource requests**: 512Mi memory, 250m CPU
- **Resource limits**: 2.5Gi memory, 1500m CPU
- **External dependencies**: PostgreSQL (data cluster), Redis (192.168.1.33:6379)
- **Features disabled**: CLIP search, face recognition, duplicate detection (ML-related)

## Testing

✅ PostgreSQL cluster bootstrapping with VectorChord extension
✅ HelmRelease reconciliation and pod health
✅ Database connectivity and NFS storage mounting
✅ HTTPS ingress and DNS resolution
✅ No OOMKilled crashes under normal usage