### PR TITLE
feat(network-segmentation): move nginx and external-dns to networking-worker

### DIFF
--- a/infrastructure/controllers/base/external-dns/release.yaml
+++ b/infrastructure/controllers/base/external-dns/release.yaml
@@ -13,6 +13,16 @@ spec:
         name: external-dns
         # namespace: external-dns
 
+  values:
+    tolerations:
+      - key: networking-only
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+      - key: networking-only
+        operator: Equal
+        value: "true"
+        effect: NoExecute
   valuesFrom:
     - kind: ConfigMap
       name: external-dns-values

--- a/infrastructure/controllers/base/nginx/release.yaml
+++ b/infrastructure/controllers/base/nginx/release.yaml
@@ -16,6 +16,15 @@ spec:
   values:
     controller:
       replicaCount: 1
+      tolerations:
+        - key: networking-only
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+        - key: networking-only
+          operator: Equal
+          value: "true"
+          effect: NoExecute
       service:
         loadBalancerIP: 192.168.1.240
       admissionWebhooks:


### PR DESCRIPTION
## Summary
- Add tolerations to nginx-ingress and external-dns HelmReleases for the `networking-only=true` taints on k3s-nixos-networking-worker
- Consolidates all networking services (ingress + DNS) on the dedicated networking node
- Frees resources on the control-plane node (currently 69% memory usage)

## Test plan
- [ ] Merge to main
- [ ] Flux reconciles and moves nginx-ingress pod to networking-worker
- [ ] Flux reconciles and moves external-dns pod to networking-worker
- [ ] Verify pods are running: `kubectl -n ingress-nginx get pods` and `kubectl get pods -l app=external-dns`
- [ ] Confirm ingress still routes traffic correctly
- [ ] Check DNS lookups still resolve (external-dns managing records)

🤖 Generated with Claude Code