### PR TITLE
fix(storage): nfs-csi a NFSv3 — v4 ignora local_lock silenciosamente

### DIFF
--- a/apps/base/bytestash/deployment.yaml
+++ b/apps/base/bytestash/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: bytestash
 spec:
+  # Recreate: la data es SQLite en NFS con local_lock — nunca debe
+  # haber dos pods con la DB abierta a la vez
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/apps/base/dbgate/deployment.yaml
+++ b/apps/base/dbgate/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: dbgate
 spec:
+  # Recreate: la data es SQLite en NFS con local_lock — nunca debe
+  # haber dos pods con la DB abierta a la vez
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/apps/base/linkding/deployment.yaml
+++ b/apps/base/linkding/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   # labels:
   #   app: linkding
 spec:
+  # Recreate: la data es SQLite en NFS con local_lock — nunca debe
+  # haber dos pods con la DB abierta a la vez
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/apps/base/memos/deployment.yaml
+++ b/apps/base/memos/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: memos
 spec:
+  # Recreate: la data es SQLite en NFS con local_lock — nunca debe
+  # haber dos pods con la DB abierta a la vez
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/apps/base/n8n/deployment.yaml
+++ b/apps/base/n8n/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: n8n
 spec:
+  # Recreate: la data es SQLite en NFS con local_lock — nunca debe
+  # haber dos pods con la DB abierta a la vez
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/infrastructure/controllers/gordito/csi-driver-nfs/storage-class.yaml
+++ b/infrastructure/controllers/gordito/csi-driver-nfs/storage-class.yaml
@@ -10,13 +10,16 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 mountOptions:
-  - nfsvers=4
-  - noatime
-  # multiple TCP connections to the NAS per mount
-  - nconnect=4
-  # resolve flock/POSIX locks on the client instead of over NFS.
+  # NFSv3 on purpose: local_lock only works on v2/v3 — NFSv4 silently
+  # ignores it (verified 2026-07-19: CSI passed local_lock=all, kernel
+  # mounted with local_lock=none). v3 + local_lock=all is the standard
+  # recipe for SQLite-on-NFS: flock/POSIX locks resolved on the client.
   # Safe for the current consumers: config PVCs are RWO single-pod
   # (SQLite), and tdarr-cache (the one RWX PVC) does not coordinate
   # writers via file locks. Do NOT add consumers that rely on
   # cross-node file locking.
+  - nfsvers=3
   - local_lock=all
+  - noatime
+  # multiple TCP connections to the NAS per mount
+  - nconnect=4


### PR DESCRIPTION
Seguimiento de #219. El rollout demostró que **NFSv4 descarta `local_lock`** (solo existe para v2/v3): el CSI driver pasó `local_lock=all` en el mount (verificado en logs del node driver) y el kernel montó con `local_lock=none` igual. `noatime` y `nconnect` sí aplicaron.

Fix: el export de configs pasa a `nfsvers=3 + local_lock=all` (receta estándar para SQLite sobre NFS; el NAS ya sirve v3 — `+2 +3 +4` en `/proc/fs/nfsd/versions`).

**Gran simplificación del rollout**: los superblocks v3 y v4 de un mismo export son independientes, así que cada pod que reinicia monta v3 fresco con las opciones correctas — ya no hace falta la ventana de scale-down simultáneo (que además Flux saboteaba re-escalando los deployments a mitad de ventana). Script v3 en el PR hermano de homelab-private.

Media queda en v4 (sus PVs no cambian).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165BG8mz2DpYvnjDqvcJYZb